### PR TITLE
Add support for running against custom hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ TestResults/
 *.nupkg
 _ReSharper.*
 *.csproj.user
+*.sln.ide

--- a/StacMan.Tests/IntegrationTests.cs
+++ b/StacMan.Tests/IntegrationTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace StackExchange.StacMan.Tests
+{
+    [TestClass] // these actually talk over the network
+    public class IntegrationTests
+    {
+
+        [TestMethod]
+        public void BasicTest_NoHost()
+        {
+            Execute(null);
+        }
+
+        [TestMethod]
+        public void BasicTest_BlankHost()
+        {
+            Execute(" ");
+        }
+
+        [TestMethod]
+        public void BasicTest_DefaultHost()
+        {
+            Execute("api.stackexchange.com");
+        }
+
+        private void Execute(string host)
+        {
+            var client = new StacManClient();
+            if (host != null)
+                client.SetHost(host);
+
+            if (string.IsNullOrWhiteSpace(host)) host = "api.stackexchange.com";
+            var sites = client.Sites.GetAll(pagesize: 50).Result;
+            Assert.AreEqual("http://" + host + "/2.0/sites?pagesize=50", sites.ApiUrl);
+            Assert.AreEqual(50, sites.Data.Items.Count());
+            Assert.IsTrue(sites.Data.HasMore);
+        }
+    }
+}

--- a/StacMan.Tests/StacMan.Tests.csproj
+++ b/StacMan.Tests/StacMan.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ApiVersion21Tests.cs" />
     <Compile Include="BackoffTests.cs" />
     <Compile Include="InfoMethodTests.cs" />
+    <Compile Include="IntegrationTests.cs" />
     <Compile Include="QuestionMethodTests.cs" />
     <Compile Include="SiteMethodTests.cs" />
     <Compile Include="TagMethodTests.cs" />

--- a/StacMan/ApiUrlBuilder.cs
+++ b/StacMan/ApiUrlBuilder.cs
@@ -9,9 +9,10 @@ namespace StackExchange.StacMan
 {
     internal class ApiUrlBuilder
     {
-        public ApiUrlBuilder(string apiVersion, string relativeUrl, bool useHttps = false)
+        public ApiUrlBuilder(string host, string apiVersion, string relativeUrl, bool useHttps = false)
         {
-            BaseUrl = String.Format("{0}://api.stackexchange.com/{1}{2}{3}", useHttps ? "https" : "http", apiVersion, relativeUrl.StartsWith("/") ? "" : "/", relativeUrl);
+            if (string.IsNullOrWhiteSpace(host)) host = "api.stackexchange.com";
+            BaseUrl = String.Format("{0}://{1}/{2}{3}{4}", useHttps ? "https" : "http", host, apiVersion, relativeUrl.StartsWith("/") ? "" : "/", relativeUrl);
             QueryStringParameters = new NameValueCollection();
         }
 

--- a/StacMan/Codegen/Methods.tt
+++ b/StacMan/Codegen/Methods.tt
@@ -177,7 +177,7 @@ namespace StackExchange.StacMan
         {
 #>
 
-            var ub = new ApiUrlBuilder(Version, String.Format("<#= urlTemplate #>", <#=
+            var ub = new ApiUrlBuilder(host, Version, String.Format("<#= urlTemplate #>", <#=
                 String.Join(", ", urlParams.Select(p =>
                     {
                         var param = requiredParams.Single(rp => rp.Name == p);
@@ -199,7 +199,7 @@ namespace StackExchange.StacMan
         {
 #>
 
-            var ub = new ApiUrlBuilder(Version, "<#= url #>", useHttps: <#= authRequired ? "true" : "false" #>);
+            var ub = new ApiUrlBuilder(host, Version, "<#= url #>", useHttps: <#= authRequired ? "true" : "false" #>);
 
 <#
         }

--- a/StacMan/Codegen/StacManClient.AccessTokenMethods.cs
+++ b/StacMan/Codegen/StacManClient.AccessTokenMethods.cs
@@ -27,7 +27,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(accessTokens, "accessTokens");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/access-tokens/{0}/invalidate", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/access-tokens/{0}/invalidate", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);
@@ -36,12 +36,18 @@ namespace StackExchange.StacMan
             return CreateApiTask<AccessToken>(ub, HttpMethod.GET, "/access-tokens/{accessTokens}/invalidate");
         }
 
+        public void SetHost(string host)
+        {
+            this.host = host;
+        }
+        private string host;
+
         Task<StacManResponse<AccessToken>> IAccessTokenMethods.Get(IEnumerable<string> accessTokens, string filter, int? page, int? pagesize)
         {
             ValidateEnumerable(accessTokens, "accessTokens");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/access-tokens/{0}", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/access-tokens/{0}", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);

--- a/StacMan/Codegen/StacManClient.AnswerMethods.cs
+++ b/StacMan/Codegen/StacManClient.AnswerMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/answers", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/answers", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -53,7 +53,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/answers/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/answers/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -78,7 +78,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/answers/{0}/comments", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/answers/{0}/comments", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.ApplicationMethods.cs
+++ b/StacMan/Codegen/StacManClient.ApplicationMethods.cs
@@ -27,7 +27,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(accessTokens, "accessTokens");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/apps/{0}/de-authenticate", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/apps/{0}/de-authenticate", String.Join(";", accessTokens.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);

--- a/StacMan/Codegen/StacManClient.BadgeMethods.cs
+++ b/StacMan/Codegen/StacManClient.BadgeMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname, mintype: mintype, maxtype: maxtype);
 
-            var ub = new ApiUrlBuilder(Version, "/badges", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/badges", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -56,7 +56,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname, mintype: mintype, maxtype: maxtype);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/badges/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/badges/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -82,7 +82,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/badges/name", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/badges/name", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -106,7 +106,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/badges/recipients", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/badges/recipients", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -124,7 +124,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/badges/{0}/recipients", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/badges/{0}/recipients", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -142,7 +142,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/badges/tags", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/badges/tags", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.CommentMethods.cs
+++ b/StacMan/Codegen/StacManClient.CommentMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/comments", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/comments", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -53,7 +53,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/comments/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/comments/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -77,7 +77,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidateMinApiVersion("2.1");
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/comments/{0}/delete", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/comments/{0}/delete", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -94,7 +94,7 @@ namespace StackExchange.StacMan
             ValidateString(body, "body");
             ValidateMinApiVersion("2.1");
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/comments/{0}/edit", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/comments/{0}/edit", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);

--- a/StacMan/Codegen/StacManClient.ErrorMethods.cs
+++ b/StacMan/Codegen/StacManClient.ErrorMethods.cs
@@ -26,7 +26,7 @@ namespace StackExchange.StacMan
         {
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/errors", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/errors", useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);
@@ -38,7 +38,7 @@ namespace StackExchange.StacMan
         Task<StacManResponse<Error>> IErrorMethods.Simulate(int id, string filter)
         {
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/errors/{0}", id), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/errors/{0}", id), useHttps: false);
 
             ub.AddParameter("filter", filter);
 

--- a/StacMan/Codegen/StacManClient.EventMethods.cs
+++ b/StacMan/Codegen/StacManClient.EventMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/events", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/events", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);

--- a/StacMan/Codegen/StacManClient.FilterMethods.cs
+++ b/StacMan/Codegen/StacManClient.FilterMethods.cs
@@ -26,7 +26,7 @@ namespace StackExchange.StacMan
         {
             ValidateEnumerable(filters, "filters");
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/filters/{0}", String.Join(";", filters.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/filters/{0}", String.Join(";", filters.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("filter", filter);
 
@@ -36,7 +36,7 @@ namespace StackExchange.StacMan
         Task<StacManResponse<Filter>> IFilterMethods.Create(string filter, IEnumerable<string> include, IEnumerable<string> exclude, string @base, bool? @unsafe)
         {
 
-            var ub = new ApiUrlBuilder(Version, "/filters/create", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/filters/create", useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("include", include);

--- a/StacMan/Codegen/StacManClient.InboxMethods.cs
+++ b/StacMan/Codegen/StacManClient.InboxMethods.cs
@@ -27,7 +27,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/inbox", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/inbox", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);
@@ -42,7 +42,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/inbox/unread", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/inbox/unread", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.InfoMethods.cs
+++ b/StacMan/Codegen/StacManClient.InfoMethods.cs
@@ -26,7 +26,7 @@ namespace StackExchange.StacMan
         {
             ValidateString(site, "site");
 
-            var ub = new ApiUrlBuilder(Version, "/info", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/info", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.NotificationMethods.cs
+++ b/StacMan/Codegen/StacManClient.NotificationMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/notifications", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/notifications", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);
@@ -44,7 +44,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/notifications/unread", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/notifications/unread", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.PostMethods.cs
+++ b/StacMan/Codegen/StacManClient.PostMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/posts", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/posts", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -53,7 +53,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/posts/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/posts/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -78,7 +78,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/posts/{0}/comments", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/posts/{0}/comments", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -103,7 +103,7 @@ namespace StackExchange.StacMan
             ValidateString(body, "body");
             ValidateMinApiVersion("2.1");
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/posts/{0}/comments/add", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/posts/{0}/comments/add", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -120,7 +120,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/posts/{0}/revisions", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/posts/{0}/revisions", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -139,7 +139,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/posts/{0}/suggested-edits", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/posts/{0}/suggested-edits", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.PrivilegeMethods.cs
+++ b/StacMan/Codegen/StacManClient.PrivilegeMethods.cs
@@ -27,7 +27,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/privileges", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/privileges", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.QuestionMethods.cs
+++ b/StacMan/Codegen/StacManClient.QuestionMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/questions", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/questions", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -54,7 +54,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -79,7 +79,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}/answers", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}/answers", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -104,7 +104,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}/comments", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}/comments", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -129,7 +129,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}/linked", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}/linked", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -154,7 +154,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}/related", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}/related", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -178,7 +178,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/questions/{0}/timeline", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/questions/{0}/timeline", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -196,7 +196,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/questions/featured", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/questions/featured", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -221,7 +221,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/questions/unanswered", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/questions/unanswered", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -246,7 +246,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/questions/no-answers", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/questions/no-answers", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.RevisionMethods.cs
+++ b/StacMan/Codegen/StacManClient.RevisionMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/revisions/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/revisions/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.SearchMethods.cs
+++ b/StacMan/Codegen/StacManClient.SearchMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/search", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/search", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -56,7 +56,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/search/advanced", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/search/advanced", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -94,7 +94,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/similar", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/similar", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.SiteMethods.cs
+++ b/StacMan/Codegen/StacManClient.SiteMethods.cs
@@ -26,7 +26,7 @@ namespace StackExchange.StacMan
         {
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/sites", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/sites", useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);

--- a/StacMan/Codegen/StacManClient.SuggestedEditMethods.cs
+++ b/StacMan/Codegen/StacManClient.SuggestedEditMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, "/suggested-edits", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/suggested-edits", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -51,7 +51,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/suggested-edits/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/suggested-edits/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.TagMethods.cs
+++ b/StacMan/Codegen/StacManClient.TagMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/tags", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/tags", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -56,7 +56,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/info", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/info", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -82,7 +82,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/tags/moderator-only", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/tags/moderator-only", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -109,7 +109,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/tags/required", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/tags/required", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -136,7 +136,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/tags/synonyms", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/tags/synonyms", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -160,7 +160,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(tags, "tags");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/faq", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/faq", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -176,7 +176,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(tags, "tags");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/related", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/related", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -193,7 +193,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/synonyms", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/synonyms", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -217,7 +217,7 @@ namespace StackExchange.StacMan
             ValidateString(tag, "tag");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/top-answerers/{1}", tag, period), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/top-answerers/{1}", tag, period), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -233,7 +233,7 @@ namespace StackExchange.StacMan
             ValidateString(tag, "tag");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/top-askers/{1}", tag, period), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/top-askers/{1}", tag, period), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -249,7 +249,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(tags, "tags");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/tags/{0}/wikis", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/tags/{0}/wikis", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);

--- a/StacMan/Codegen/StacManClient.UserMethods.cs
+++ b/StacMan/Codegen/StacManClient.UserMethods.cs
@@ -28,7 +28,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/users", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/users", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -56,7 +56,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -83,7 +83,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/me", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -111,7 +111,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/answers", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/answers", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -136,7 +136,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/answers", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/answers", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -162,7 +162,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname, mintype: mintype, maxtype: maxtype, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/badges", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/badges", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -191,7 +191,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, minrank: minrank, maxrank: maxrank, minname: minname, maxname: maxname, mintype: mintype, maxtype: maxtype, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, "/me/badges", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/badges", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -221,7 +221,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/comments", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/comments", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -246,7 +246,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/comments", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/comments", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -272,7 +272,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/comments/{1}", String.Join(";", ids), toid), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/comments/{1}", String.Join(";", ids), toid), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -297,7 +297,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/me/comments/{0}", toid), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/me/comments/{0}", toid), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -323,7 +323,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/favorites", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/favorites", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -348,7 +348,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/favorites", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/favorites", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -374,7 +374,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/mentioned", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/mentioned", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -399,7 +399,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/mentioned", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/mentioned", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -424,7 +424,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/merges", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/merges", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);
@@ -439,7 +439,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/merges", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/merges", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);
@@ -456,7 +456,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/notifications", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/notifications", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -474,7 +474,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/notifications", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/notifications", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -492,7 +492,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/notifications/unread", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/notifications/unread", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -510,7 +510,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/notifications/unread", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/notifications/unread", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -526,7 +526,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/privileges", id), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/privileges", id), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -542,7 +542,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/privileges", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/privileges", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -560,7 +560,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/questions", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/questions", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -585,7 +585,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/questions", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/questions", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -611,7 +611,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/questions/featured", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/questions/featured", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -636,7 +636,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/questions/featured", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/questions/featured", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -662,7 +662,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/questions/featured", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/questions/featured", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -687,7 +687,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/questions/featured", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/questions/featured", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -713,7 +713,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/questions/unaccepted", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/questions/unaccepted", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -738,7 +738,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/questions/unaccepted", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/questions/unaccepted", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -764,7 +764,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/questions/unanswered", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/questions/unanswered", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -789,7 +789,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, "/me/questions/unanswered", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/questions/unanswered", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -814,7 +814,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/reputation", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/reputation", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -831,7 +831,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidateString(access_token, "access_token");
 
-            var ub = new ApiUrlBuilder(Version, "/me/reputation", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/reputation", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -847,7 +847,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/reputation-history", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/reputation-history", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -864,7 +864,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/reputation-history", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/reputation-history", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -882,7 +882,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/reputation-history/full", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/reputation-history/full", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -900,7 +900,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/reputation-history/full", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/reputation-history/full", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -918,7 +918,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/suggested-edits", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/suggested-edits", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -941,7 +941,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate);
 
-            var ub = new ApiUrlBuilder(Version, "/me/suggested-edits", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/suggested-edits", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -965,7 +965,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/tags", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/tags", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -992,7 +992,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/me/tags", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/tags", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1020,7 +1020,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/tags/{1}/top-answers", id, String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/tags/{1}/top-answers", id, String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1046,7 +1046,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/me/tags/{0}/top-answers", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/me/tags/{0}/top-answers", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1072,7 +1072,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/tags/{1}/top-questions", id, String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/tags/{1}/top-questions", id, String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1098,7 +1098,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, mindate: mindate, maxdate: maxdate, min: min, max: max);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/me/tags/{0}/top-questions", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/me/tags/{0}/top-questions", String.Join(";", tags.Select(HttpUtility.UrlEncode))), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1123,7 +1123,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/timeline", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/timeline", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1141,7 +1141,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/timeline", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/timeline", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1159,7 +1159,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/top-answer-tags", id), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/top-answer-tags", id), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1176,7 +1176,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/top-answer-tags", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/top-answer-tags", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1192,7 +1192,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/top-answer-tags", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/top-answer-tags", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1208,7 +1208,7 @@ namespace StackExchange.StacMan
             ValidateString(site, "site");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/top-question-tags", id), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/top-question-tags", id), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1225,7 +1225,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/top-question-tags", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/top-question-tags", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1241,7 +1241,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/top-question-tags", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/top-question-tags", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1258,7 +1258,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/write-permissions", id), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/write-permissions", id), useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1275,7 +1275,7 @@ namespace StackExchange.StacMan
             ValidateMinApiVersion("2.1");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/write-permissions", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/write-permissions", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1292,7 +1292,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/users/moderators", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/users/moderators", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1318,7 +1318,7 @@ namespace StackExchange.StacMan
             ValidatePaging(page, pagesize);
             ValidateSortMinMax(sort, min: min, max: max, mindate: mindate, maxdate: maxdate, minname: minname, maxname: maxname);
 
-            var ub = new ApiUrlBuilder(Version, "/users/moderators/elected", useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, "/users/moderators/elected", useHttps: false);
 
             ub.AddParameter("site", site);
             ub.AddParameter("filter", filter);
@@ -1344,7 +1344,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/inbox", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/inbox", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1361,7 +1361,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/inbox", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/inbox", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1378,7 +1378,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/inbox/unread", id), useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/inbox/unread", id), useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1396,7 +1396,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/inbox/unread", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/inbox/unread", useHttps: true);
 
             ub.AddParameter("site", site);
             ub.AddParameter("access_token", access_token);
@@ -1413,7 +1413,7 @@ namespace StackExchange.StacMan
             ValidateEnumerable(ids, "ids");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, String.Format("/users/{0}/associated", String.Join(";", ids)), useHttps: false);
+            var ub = new ApiUrlBuilder(host, Version, String.Format("/users/{0}/associated", String.Join(";", ids)), useHttps: false);
 
             ub.AddParameter("filter", filter);
             ub.AddParameter("page", page);
@@ -1427,7 +1427,7 @@ namespace StackExchange.StacMan
             ValidateString(access_token, "access_token");
             ValidatePaging(page, pagesize);
 
-            var ub = new ApiUrlBuilder(Version, "/me/associated", useHttps: true);
+            var ub = new ApiUrlBuilder(host, Version, "/me/associated", useHttps: true);
 
             ub.AddParameter("access_token", access_token);
             ub.AddParameter("filter", filter);

--- a/StacMan/Properties/AssemblyInfo.cs
+++ b/StacMan/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: InternalsVisibleTo("StacMan.Tests")]

--- a/StacMan/StacMan.csproj
+++ b/StacMan/StacMan.csproj
@@ -279,6 +279,7 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Types.ignore</LastGenOutput>
     </None>
+    <None Include="StacMan.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />


### PR DESCRIPTION
Internally, SE use a slightly different domain, to avoid looping out and back in between networks; the API remains identical. This change request adds an entirely optional client.SetHost(string) method, which (if used) overrides the "api.stackexchange.com" default.
